### PR TITLE
Use smaller module

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "git://github.com/Constellation/ibrik.git"
   },
   "dependencies": {
-    "lodash": "~2.4.1",
+    "lodash.sortedindex": "~2.4.1",
     "coffee-script-redux": "=2.0.0-beta8",
     "istanbul": "~0.2.4",
     "estraverse": "~1.5.0",

--- a/src/instrumenter.coffee
+++ b/src/instrumenter.coffee
@@ -24,7 +24,7 @@ coffee = require 'coffee-script-redux'
 istanbul = require 'istanbul'
 escodegen = require 'escodegen'
 estraverse = require 'estraverse'
-_ = require 'lodash'
+sortedIndex = require 'lodash.sortedindex'
 
 class StructuredCode
     constructor: (code) ->
@@ -47,7 +47,7 @@ class StructuredCode
         @loc(offset).line
 
     loc: (offset) ->
-        index = _.sortedIndex @cursors, offset
+        index = sortedIndex @cursors, offset
         if @cursors.length > index and @cursors[index] is offset
             column = 0
             line = index + 1


### PR DESCRIPTION
Currently, _ibrik_ depends on [`lodash`](https://npmjs.org/package/lodash) module but uses only `sortedIndex` method.
So I introduced [`lodash.sortedindex`](https://npmjs.org/package/lodash.sortedindex) module, the single-feature build of Lo-Dash.
