### PR TITLE
allow multiple reports to be specified

### DIFF
--- a/lib/cover.js
+++ b/lib/cover.js
@@ -11,7 +11,7 @@ void function () {
   existsSync = fs.existsSync || path.existsSync;
   DEFAULT_REPORT_FORMAT = 'lcov';
   module.exports = function (opts, callback) {
-    var args, cache$, cmd, e, excludes, file, reportClassName, reportClassNames, reportingDir, runFn;
+    var args, cache$, cmd, e, excludes, file, reportClassName, reportClassNames, reportingDir, reports, runFn;
     cache$ = opts._;
     cmd = cache$[0];
     file = cache$[1];
@@ -38,10 +38,11 @@ void function () {
     reportingDir = '' + (opts.dir || path.resolve(process.cwd(), 'coverage'));
     mkdirp.sync(reportingDir);
     reportClassNames = opts.report || DEFAULT_REPORT_FORMAT;
+    reports = [];
     if (reportClassNames instanceof Array) {
       for (var i$ = 0, length$ = reportClassNames.length; i$ < length$; ++i$) {
         reportClassName = reportClassNames[i$];
-        reportClassNames.push(istanbul.Report.create(reportClassName, { dir: reportingDir }));
+        reports.push(istanbul.Report.create(reportClassName, { dir: reportingDir }));
       }
     } else {
       reports.push(istanbul.Report.create(reportClassNames, { dir: reportingDir }));

--- a/src/cover.coffee
+++ b/src/cover.coffee
@@ -57,9 +57,10 @@ module.exports = (opts, callback) ->
     mkdirp.sync reportingDir
 
     reportClassNames = opts.report or DEFAULT_REPORT_FORMAT
+    reports = []
     if reportClassNames instanceof Array
         for reportClassName in reportClassNames
-            reportClassNames.push(istanbul.Report.create(reportClassName, { dir: reportingDir }))
+            reports.push(istanbul.Report.create(reportClassName, { dir: reportingDir }))
     else
         reports.push(istanbul.Report.create(reportClassNames, { dir: reportingDir }))
 


### PR DESCRIPTION
Allows processing of multiple report options, ie. --report html --report cobertura.
